### PR TITLE
GitHub Linguist support for adblock filters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.txt linguist-language=AdBlock linguist-detectable

--- a/Filterlist.txt
+++ b/Filterlist.txt
@@ -1,3 +1,4 @@
+[uBlock Origin; AdGuard]
 # Title: Grayware Blocklist
 # Updated: 2022-Aug-30
 # Expires: 1 month (update frequency)


### PR DESCRIPTION
GitHub has been supporting adblock syntax highlighting since September 5th. This PR will help you turn it on.

Further informations:
- Syntax highlighter repository: https://github.com/ameshkov/VscodeAdblockSyntax
- How Linguist works: https://github.com/github/linguist/blob/master/docs/how-linguist-works.md
- Linguist overrides: https://github.com/github/linguist/blob/master/docs/overrides.md
- Linguist commit: https://github.com/github/linguist/commit/e78ef71af3600f96b9a40a06511ebbe3797e7401